### PR TITLE
Use project.el for projectile functionality.

### DIFF
--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -4,7 +4,7 @@
 
 ;; Author: Lowe Thiderman <lowe.thiderman@gmail.com>
 ;; URL: https://github.com/thiderman/makefile-executor.el
-;; Package-Version: 20170613
+;; Package-Version: 2022-09-06
 ;; Version: 0.2.1
 ;; Package-Requires: ((emacs "27.1") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
 ;; Keywords: processes
@@ -58,7 +58,7 @@
 (require 'make-mode)
 (require 's)
 (require 'projectile nil t)
-(require 'project nil t)
+(require 'project)
 
 (defvar makefile-executor-mode-map
   (let ((map (make-sparse-keymap)))
@@ -258,9 +258,9 @@ argument is given, always prompt."
 
   (let ((targets (makefile-executor-get-cache)))
     (if (or arg (not targets))
-        (if (or (featurep 'projectile) (featurep 'project))
+        (if (project-current)
             (makefile-executor-execute-project-target)
-          (makefile-executor-execute-target))
+          (makefile-executor-execute-target (buffer-file-name)))
       (makefile-executor-execute-target
        (car targets)
        (cadr targets)))))

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -5,7 +5,7 @@
 ;; Author: Lowe Thiderman <lowe.thiderman@gmail.com>
 ;; URL: https://github.com/thiderman/makefile-executor.el
 ;; Package-Version: 20170613
-;; Version: 0.2.0
+;; Version: 0.2.1
 ;; Package-Requires: ((emacs "27.1") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
 ;; Keywords: processes
 

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -41,10 +41,9 @@
 ;;   '`C-c C-d'` in `makefile-mode` when 'makefile-executor-mode'` is enabled.
 ;; - Calculation of variables et.c.; $(BINARY) will show up as what it
 ;;   evaluates to.
-;; - If `projectile' is installed, execution from any buffer in a
-;;   project.  If more than one is found,
-;;   an interactive prompt for one is shown.  This is added to the
-;;   `projectile-commander' on the 'm' key.
+;; - Via `project.el', execution from any buffer in a project.
+;;   If more than one makefile is found, an interactive prompt for one is shown.
+;;   If `projectile' is installed, this is added to the `projectile-commander' on the 'm' key.
 ;;
 ;; To enable it, use the following snippet to add the hook into 'makefile-mode':
 ;;

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -216,11 +216,13 @@ If none can be found, returns empty string."
   (let* ((bn (or (buffer-file-name) default-directory))
          (fn (or (locate-dominating-file bn "Makefile")
                  (locate-dominating-file bn "makefile")))
-         (relpath (file-relative-name fn (project-root (project-current)))))
+         (root (if (project-current) (project-root (project-current)) file-relative-name) )
+         (relpath (file-relative-name (or fn root) root)))
     ;; If we are at the root, we don't need the initial
     ;; input. If we have it as `./`, the Makefile at
     ;; the root will not be selectable, which is confusing. Hence, we
     ;; remove that
+    (unless fn (user-error "No Makefiles found in project"))
     (if (not (s-equals? relpath "./"))
         relpath
       "")))

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -160,7 +160,7 @@ FILENAME defaults to current buffer."
 
 If you are in a project, this uses `project-root'. If
   not, it uses the current filename."
-  (puthash (if (project-current) (project-root (project-current)) filename)
+  (puthash (makefile-executor--project-root filename)
            (list filename target)
            makefile-executor-cache))
 
@@ -169,9 +169,7 @@ If you are in a project, this uses `project-root'. If
 
 If you are in a project, this uses `project-root'. If
   not, just use the current filename."
-  (gethash (if (project-current)
-               (project-root (project-current))
-             (file-truename buffer-file-name))
+  (gethash (makefile-executor--project-root (file-truename buffer-file-name))
            makefile-executor-cache))
 
 (defun makefile-executor-makefile-p (f)
@@ -181,6 +179,11 @@ If you are in a project, this uses `project-root'. If
 (defun makefile-executor-get-makefiles ()
   (-filter 'makefile-executor-makefile-p
            (project-files (project-current))))
+
+(defun makefile-executor--project-root (&optional otherwise)
+  (if (project-current)
+      (project-root (project-current))
+    otherwise))
 
 ;;;###autoload
 (defun makefile-executor-execute-project-target ()
@@ -216,7 +219,7 @@ If none can be found, returns empty string."
   (let* ((bn (or (buffer-file-name) default-directory))
          (fn (or (locate-dominating-file bn "Makefile")
                  (locate-dominating-file bn "makefile")))
-         (root (if (project-current) (project-root (project-current)) file-relative-name) )
+         (root (makefile-executor--project-root nil))
          (relpath (file-relative-name (or fn root) root)))
     ;; If we are at the root, we don't need the initial
     ;; input. If we have it as `./`, the Makefile at

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -157,10 +157,10 @@ FILENAME defaults to current buffer."
                      target))))
 
 (defun makefile-executor-store-cache (filename target)
-  "Stores the FILENAME and TARGET in the cache.
+  "Store the FILENAME and TARGET in the cache.
 
-If `projectile' is installed, use the `projectile-project-root'. If
-  not, just use the current filename."
+If you are in a project, this uses `project-root'. If
+  not, it uses the current filename."
   (puthash (if (project-current) (project-root (project-current)) filename)
            (list filename target)
            makefile-executor-cache))
@@ -168,7 +168,7 @@ If `projectile' is installed, use the `projectile-project-root'. If
 (defun makefile-executor-get-cache ()
   "Gets the cache for the current project or Makefile.
 
-If `projectile' is installed, use the `projectile-project-root'. If
+If you are in a project, this uses `project-root'. If
   not, just use the current filename."
   (gethash (if (project-current)
                (project-root (project-current))

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -5,7 +5,7 @@
 ;; Author: Lowe Thiderman <lowe.thiderman@gmail.com>
 ;; URL: https://github.com/thiderman/makefile-executor.el
 ;; Package-Version: 20220906
-;; Version: 0.2.1
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "27.1") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
 ;; Keywords: processes
 

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -4,7 +4,7 @@
 
 ;; Author: Lowe Thiderman <lowe.thiderman@gmail.com>
 ;; URL: https://github.com/thiderman/makefile-executor.el
-;; Package-Version: 2022-09-06
+;; Package-Version: 20220906
 ;; Version: 0.2.1
 ;; Package-Requires: ((emacs "27.1") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
 ;; Keywords: processes

--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -5,8 +5,8 @@
 ;; Author: Lowe Thiderman <lowe.thiderman@gmail.com>
 ;; URL: https://github.com/thiderman/makefile-executor.el
 ;; Package-Version: 20170613
-;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.3") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
+;; Version: 0.2.0
+;; Package-Requires: ((emacs "27.1") (dash "2.11.0") (f "0.11.0") (s "1.10.0"))
 ;; Keywords: processes
 
 ;; This file is not part of GNU Emacs.
@@ -103,6 +103,14 @@ Bindings in `makefile-mode':
    ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
    makefile-executor-special-target makefile-executor-special-target)
   "Target used to list all other Makefile targets.")
+
+(defun makefile-executor-project-root ()
+  "Return the path to the project root, computed from projectile or project.el."
+  (cond
+   ((featurep 'projectile) (projectile-project-root))
+   ((project-current) (project-root (project-current)))
+   (t (user-error "Can't detect project root, install projectile or project.el")))
+  )
 
 (defun makefile-executor-get-targets (filename)
   "Return a list of all the targets of a Makefile.


### PR DESCRIPTION
As per discussion in https://github.com/thiderman/makefile-executor.el/issues/10, here’s how a replacement of projectile with project.el would look (except for the call to `def-projectile-commander-method` that’s guarded by a `featurep` invocation.