### PR TITLE
Use grep -E instead of egrep

### DIFF
--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -100,7 +100,7 @@ Bindings in `makefile-mode':
 ;; Based on http://stackoverflow.com/a/26339924/983746
 (defvar makefile-executor-list-target-code
   (format
-   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
+   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
    makefile-executor-special-target makefile-executor-special-target)
   "Target used to list all other Makefile targets.")
 


### PR DESCRIPTION
Latest version print those messages :

egrep: warning: egrep is obsolescent; using grep -E

which seems to cause issues to detect targets.

Changing it to grep -E by default instead

(an article mentions the reasons of the changes here: https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep)

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>