### PR TITLE
Skip the unnecessary tmp files

### DIFF
--- a/makefile-executor.el
+++ b/makefile-executor.el
@@ -100,7 +100,7 @@ Bindings in `makefile-mode':
 ;; Based on http://stackoverflow.com/a/26339924/983746
 (defvar makefile-executor-list-target-code
   (format
-   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
+   ".PHONY: %s\n%s:\n	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\\n)# Files(\\n|$$)/,/(^|\\n)# Finished Make data base/ {if ($$1 !~ \"^[#.]\") {print $$1}}' | sort | grep -E -v -e '^[^[:alnum:]]' -e '^$@$$'\n"
    makefile-executor-special-target makefile-executor-special-target)
   "Target used to list all other Makefile targets.")
 


### PR DESCRIPTION
`makefile-executor-get-targets` writes a tmp file but it really doesn't need to. This changes `makefile-executor-get-targets` so that it gets the Makefile database from the existing Makefile. It doesn't change any other behavior of `makefile-executor-get-targets`, so it shouldn't affect the rest of the package